### PR TITLE
Agregar pestaña de análisis histórico de base de datos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ plotly>=5.15.0
 openpyxl>=3.1.0
 xlsxwriter>=3.1.0
 python-dateutil>=2.8.0
+requests>=2.31.0


### PR DESCRIPTION
Add a new "Histórico DB" tab to the "Analizar Inventarios" section to visualize historical negative inventory data from an external SQLite database hosted on GitHub.

This PR integrates a new tab that replicates the design, filters, and visualizations of the existing "Súper Análisis" tab, but sources data from a cached SQLite database downloaded from GitHub, providing historical context and cost-specific metrics.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f394eb8-0752-46a3-83cc-ba40780f8ce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f394eb8-0752-46a3-83cc-ba40780f8ce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

