### PR TITLE
fix: replace deprecated .style.applymap() with .style.map() for pandas 2.2+ compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -1387,7 +1387,7 @@ def main():
                     }
                     return colors.get(val, "")
                 
-                styled_analisis = analisis_filtered.style.applymap(format_severity, subset=['Severidad'])
+                styled_analisis = analisis_filtered.style.map(format_severity, subset=['Severidad'])
                 st.dataframe(styled_analisis, width='stretch', height=400)
             
             with tab2:
@@ -1494,7 +1494,7 @@ def main():
                 
                 # Aplicar estilo y mostrar tabla
                 if not super_display.empty:
-                    styled_super = super_display.style.applymap(colorear_super_analisis)
+                    styled_super = super_display.style.map(colorear_super_analisis)
                     st.dataframe(styled_super, width='stretch', height=500)
                     
                     # Estadísticas rápidas - con mejor espaciado
@@ -2552,7 +2552,7 @@ def main():
                     
                     if len(historico_pivot_display) <= 2000:
                         # ✅ Estilo COMPLETO con colores por gravedad
-                        styled_pivot = historico_pivot_display.style.applymap(
+                        styled_pivot = historico_pivot_display.style.map(
                             color_negativo_celda,
                             subset=fecha_cols_str
                         )
@@ -2574,7 +2574,7 @@ def main():
                                 return f'background-color: {color_celdas_none}'
                             return ''
                         
-                        styled_pivot = historico_pivot_display.style.applymap(
+                        styled_pivot = historico_pivot_display.style.map(
                             color_solo_vacias,
                             subset=fecha_cols_str
                         )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Two `AttributeError` crashes were occurring in the deployed Streamlit app:

- **Analizar Inventarios → Problemas por Severidad** (line 1390)
- **Histórico DB** (lines 2555 and 2577)

The root cause is that pandas 2.2.0 removed the `.style.applymap()` method, which had been deprecated since pandas 2.1.0. The replacement is `.style.map()`, which has the same signature and behavior.

## Changes

Replaced all 4 occurrences of `.style.applymap(...)` with `.style.map(...)` in `app.py`:

- Line 1390: `format_severity` styling for the Severidad column
- Line 1497: `colorear_super_analisis` styling for the Súper Análisis table
- Line 2555: `color_negativo_celda` styling for the Histórico pivot table (full style)
- Line 2577: `color_solo_vacias` styling for the Histórico pivot table (simplified style)

No logic or behavior was changed — only the method name, which is a direct drop-in replacement.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-179db89c-81d2-4aa6-aa90-3e212b43f45f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-179db89c-81d2-4aa6-aa90-3e212b43f45f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

